### PR TITLE
Updates for Senzing API Server default ports for HTTP and HTTPS

### DIFF
--- a/lists/ports-used-in-demonstrations.md
+++ b/lists/ports-used-in-demonstrations.md
@@ -47,7 +47,7 @@ Open range: 8250-8265
 
 ### 8250
 
-- [Senzing API server](https://github.com/Senzing/senzing-api-server)
+- [Senzing API server](https://github.com/Senzing/senzing-api-server) default HTTP Port.
 
 ### 8251
 
@@ -80,6 +80,10 @@ Open range: 8250-8265
 ### 8260
 
 - Reserved for tools
+
+### 8263
+
+- [Senzing API server](https://github.com/Senzing/senzing-api-server) default HTTPS Port.
 
 ## Other
 


### PR DESCRIPTION
Noted that 8250 is the **default** HTTP port for Senzing API Server.

Added port 8263 as the default HTTPS port for Senzing API Server

