### PR TITLE
remove entity-search-web-app-console

### DIFF
--- a/HOWTO/build-docker-images-from-staging.md
+++ b/HOWTO/build-docker-images-from-staging.md
@@ -179,28 +179,6 @@
     docker push senzing/sshd:staging
     ```
 
-### senzing/entity-search-web-app-console
-
-1. Build `senzing/entity-search-web-app-console:staging`.
-   Example:
-
-    ```console
-    docker pull senzing/senzingapi-tools:staging
-
-    docker build \
-        --build-arg BASE_IMAGE=senzing/senzingapi-tools:staging \
-        --no-cache \
-        --tag senzing/entity-search-web-app-console:staging \
-        https://github.com/senzing/entity-search-web-app-console.git#main
-    ```
-
-1. Push to DockerHub.
-   Example:
-
-    ```console
-    docker push senzing/entity-search-web-app-console:staging
-    ```
-
 ### senzing/xterm
 
 1. Build `senzing/xterm:staging`.


### PR DESCRIPTION
deprecating repo.

# Pull request questions

## Which issue does this address

remove `entity-search-web-app-console` from markdown instructions

## Why was change needed

deprecating `entity-search-web-app-console` repo
